### PR TITLE
fix: TypeScript v6 対応のため tsconfig.json を修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,8 +22,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "newLine": "LF"
   },
   "include": ["src/**/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["ESNext", "esnext.AsyncIterable", "DOM"],
     "outDir": "./dist",
     "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "Bundler",
     "lib": ["ESNext", "esnext.AsyncIterable", "DOM"],
     "outDir": "./dist",
+    "rootDir": "./src",
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,
@@ -22,6 +23,7 @@
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "newLine": "LF"
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 概要

Renovate PR #3032 (`chore(deps): update dependency typescript to v6`) が TypeScript v6 へのアップグレード時に CI エラーで失敗していたため、`tsconfig.json` を TypeScript v6 対応に修正しました。

## 発生していた CI エラー

- `TS5011`: `'rootDir' must be explicitly set` — ソースディレクトリが自動推論されていたが、TypeScript v6 では明示的な指定が必須になった
- `TS5101`: `Option 'baseUrl' is deprecated` — TypeScript v6 では `baseUrl` が非推奨となりエラーになる

## `tsconfig.json` への変更

| 変更 | 内容 | 目的 |
|---|---|---|
| 追加 | `"rootDir": "./src"` | TS5011 エラーを解消。ソースディレクトリを明示的に指定 |
| 削除 | `"baseUrl": "."` | TS5101 エラーを解消。パス解決への影響なし（後述） |
| 追加 | `"tsBuildInfoFile": "./dist/.tsbuildinfo"` | インクリメンタルビルドの問題を解消（後述） |

## `baseUrl` を削除した理由

`baseUrl: "."` は主にパス解決の起点として機能しますが、当プロジェクトではその機能を利用していません。

- `moduleResolution: "Bundler"` を使用しており、`node_modules` のモジュール解決は `baseUrl` に依存しない
- `paths` マッピングを使用していない
- ソースコード内でプロジェクトルートからの絶対パスインポートを行っていない

また、`"ignoreDeprecations": "6.0"` による抑制も検討しましたが、TypeScript 5.x では `TS5103: Invalid value for '--ignoreDeprecations'` エラーになるため採用していません。`baseUrl` の削除が最もクリーンな解決策です。

## `tsBuildInfoFile` を追加した理由

`rootDir` を明示的に設定すると `tsconfig.tsbuildinfo` がプロジェクトルートに保存されるようになります。しかし `clean` スクリプト (`rimraf dist output`) は `dist/` のみを削除するため、`tsbuildinfo` が残ります。

この状態で `compile` (`tsc -p .`) を再実行すると、`tsbuildinfo` を参照して「変更なし」と判断し、`dist/` にファイルを出力しません。その結果 `packing` (`ncc build ./dist/main.js`) が失敗します。

`tsBuildInfoFile` を `"./dist/.tsbuildinfo"` に設定することで、`clean` 時に `dist/` ごと削除され、次回の `compile` では完全ビルドが実行されます。

## 影響範囲

- `rootDir: "./src"` と `outDir: "./dist"` の組み合わせにより、`src/main.ts` → `dist/main.js` のコンパイルパスは変更なし
- `packing` スクリプト (`ncc build ./dist/main.js`) への影響なし

## 関連

- Renovate PR: #3032 (`chore(deps): update dependency typescript to v6`)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)